### PR TITLE
Add three new CloudTrail detections

### DIFF
--- a/detections/codebuild.pp
+++ b/detections/codebuild.pp
@@ -11,15 +11,70 @@ benchmark "codebuild_detections" {
   description = "This benchmark contains recommendations when scanning CloudTrail logs for CodeBuild events."
   type        = "detection"
   children = [
+    detection.codebuild_project_build_failures,
     detection.codebuild_project_environment_variable_updated,
-    detection.codebuild_project_visibility_set_public,
     detection.codebuild_project_service_role_updated,
     detection.codebuild_project_source_repository_updated,
+    detection.codebuild_project_visibility_set_public,
   ]
 
   tags = merge(local.codebuild_common_tags, {
     type = "Benchmark"
   })
+}
+
+detection "codebuild_project_build_failures" {
+  title           = "CodeBuild Project Build Failures"
+  description     = "Detect when CodeBuild projects fail repeatedly. Multiple build failures may indicate configuration issues, security vulnerabilities in code, or potential supply chain attacks, disrupting CI/CD pipelines and delaying deployment of critical fixes."
+  documentation   = file("./detections/docs/codebuild_project_build_failures.md")
+  severity        = "medium"
+  display_columns = local.detection_display_columns
+  query           = query.codebuild_project_build_failures
+
+  tags = merge(local.codebuild_common_tags, {
+    mitre_attack_ids = "TA0003:T1195"
+  })
+}
+
+query "codebuild_project_build_failures" {
+  sql = <<-EOQ
+    with failed_builds as (
+      select
+        json_extract_string(request_parameters, '$.projectName') as project_name,
+        event_time,
+        user_identity.principal_id as principal_id
+      from
+        aws_cloudtrail_log
+      where
+        event_source = 'codebuild.amazonaws.com'
+        and (
+          (event_name = 'BatchGetBuilds' and json_extract_string(response_elements, '$.builds[*].buildStatus') like '%FAILED%')
+          or (event_name = 'StopBuild')
+          or (event_name = 'RetryBuild')
+          or (event_name in ('StartBuild', 'CreateProject') and error_code is not null)
+        )
+        ${local.detection_sql_where_conditions}
+    )
+    select
+      project_name as resource,
+      count(*) as failure_count,
+      min(event_time) as first_failure,
+      max(event_time) as latest_failure,
+      array_agg(distinct principal_id) as users
+    from
+      failed_builds
+    where
+      project_name is not null
+    group by
+      project_name
+    having
+      count(*) >= 3
+    order by
+      failure_count desc,
+      latest_failure desc;
+  EOQ
+
+  tags = local.codebuild_common_tags
 }
 
 detection "codebuild_project_visibility_set_public" {

--- a/detections/codebuild_failures.pp
+++ b/detections/codebuild_failures.pp
@@ -1,0 +1,60 @@
+locals {
+  codebuild_failures_common_tags = merge(local.aws_cloudtrail_log_detections_common_tags, {
+    folder  = "CodeBuild"
+    service = "AWS/CodeBuild"
+  })
+}
+
+detection "codebuild_project_build_failures" {
+  title           = "CodeBuild Project Build Failures"
+  description     = "Detect when CodeBuild projects fail repeatedly. Multiple build failures may indicate configuration issues, security vulnerabilities in code, or potential supply chain attacks, disrupting CI/CD pipelines and delaying deployment of critical fixes."
+  documentation   = file("./detections/docs/codebuild_project_build_failures.md")
+  severity        = "medium"
+  display_columns = local.detection_display_columns
+  query           = query.codebuild_project_build_failures
+
+  tags = merge(local.codebuild_failures_common_tags, {
+    mitre_attack_ids = "TA0003:T1195"
+  })
+}
+
+query "codebuild_project_build_failures" {
+  sql = <<-EOQ
+    with failed_builds as (
+      select
+        json_extract_string(request_parameters, '$.projectName') as project_name,
+        event_time,
+        user_identity.principal_id as principal_id
+      from
+        aws_cloudtrail_log
+      where
+        event_source = 'codebuild.amazonaws.com'
+        and (
+          (event_name = 'BatchGetBuilds' and json_extract_string(response_elements, '$.builds[*].buildStatus') like '%FAILED%')
+          or (event_name = 'StopBuild')
+          or (event_name = 'RetryBuild')
+          or (event_name in ('StartBuild', 'CreateProject') and error_code is not null)
+        )
+        ${local.detection_sql_where_conditions}
+    )
+    select
+      project_name as resource,
+      count(*) as failure_count,
+      min(event_time) as first_failure,
+      max(event_time) as latest_failure,
+      array_agg(distinct principal_id) as users
+    from
+      failed_builds
+    where
+      project_name is not null
+    group by
+      project_name
+    having
+      count(*) >= 3
+    order by
+      failure_count desc,
+      latest_failure desc;
+  EOQ
+
+  tags = local.codebuild_failures_common_tags
+}

--- a/detections/docs/codebuild_project_build_failures.md
+++ b/detections/docs/codebuild_project_build_failures.md
@@ -1,0 +1,15 @@
+## Overview
+
+Detect when AWS CodeBuild projects experience repeated build failures. Multiple consecutive build failures within a short time period might indicate security issues such as:
+
+- Potential software supply chain attacks targeting dependencies
+- Injection of malicious code through compromised build scripts
+- Security vulnerabilities being caught by static code analysis
+- Configuration drift or permission issues disrupting the build pipeline
+
+This detection focuses on projects with multiple failures, which may require immediate investigation to prevent disruption to development workflows or deployment of compromised code.
+
+**References**:
+- [AWS CodeBuild Security Best Practices](https://docs.aws.amazon.com/codebuild/latest/userguide/security-best-practices.html)
+- [Building Secure CI/CD Pipelines](https://aws.amazon.com/blogs/devops/building-secure-ci-cd-pipelines/)
+- [Troubleshooting AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/troubleshooting.html)

--- a/detections/docs/ec2_spot_instance_interrupted.md
+++ b/detections/docs/ec2_spot_instance_interrupted.md
@@ -1,0 +1,14 @@
+## Overview
+
+Detect when EC2 spot instances are interrupted or terminated due to capacity reclamation or price changes. Spot instance interruptions occur when AWS needs capacity back or when spot prices exceed the maximum price specified in the request.
+
+Monitoring spot instance interruptions helps identify potential workload disruptions, allowing teams to:
+- Verify that applications are handling interruptions gracefully
+- Assess the frequency of interruptions to evaluate Spot instance reliability for specific workloads
+- Ensure data integrity during unexpected terminations
+- Adjust bidding strategies or consider alternative instance types for critical workloads
+
+**References**:
+- [EC2 Spot Instance Interruptions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html)
+- [Handling Spot Instance Interruptions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-best-practices.html#spot-instance-termination-notices)
+- [Spot Instance Advisor](https://aws.amazon.com/ec2/spot/instance-advisor/)

--- a/detections/docs/secretsmanager_rotation_failures.md
+++ b/detections/docs/secretsmanager_rotation_failures.md
@@ -1,0 +1,21 @@
+## Overview
+
+Detect when AWS Secrets Manager fails to rotate a secret. Secret rotation is a critical security practice that helps limit the impact of credential compromise and maintain compliance with security policies.
+
+Rotation failures can occur due to:
+- Lambda rotation function errors or timeouts
+- Permission issues with the rotation Lambda function
+- Invalid configuration of the secret or its rotation settings
+- Backend service issues preventing credential updates
+- Network connectivity problems
+
+Failed rotations may leave systems using outdated credentials, which could result in:
+- Extended use of potentially compromised credentials
+- Service disruptions when credentials eventually expire
+- Compliance violations for organizations requiring regular credential rotation
+- Increased risk of lateral movement if credentials are compromised
+
+**References**:
+- [AWS Secrets Manager Rotation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets.html)
+- [Troubleshooting Secret Rotation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/troubleshoot_rotation.html)
+- [Automated Rotation for AWS Secrets Manager](https://aws.amazon.com/blogs/security/how-to-use-aws-secrets-manager-securely-store-rotate-database-credentials/)

--- a/detections/ec2_spot.pp
+++ b/detections/ec2_spot.pp
@@ -1,0 +1,42 @@
+locals {
+  ec2_spot_common_tags = merge(local.aws_cloudtrail_log_detections_common_tags, {
+    folder  = "EC2"
+    service = "AWS/EC2"
+  })
+}
+
+detection "ec2_spot_instance_interrupted" {
+  title           = "EC2 Spot Instance Interrupted"
+  description     = "Detect when EC2 spot instances are interrupted. Spot instance interruptions can disrupt workloads if not properly handled, potentially causing service outages or data loss if applications aren't designed for graceful termination."
+  documentation   = file("./detections/docs/ec2_spot_instance_interrupted.md")
+  severity        = "low"
+  display_columns = local.detection_display_columns
+  query           = query.ec2_spot_instance_interrupted
+
+  tags = merge(local.ec2_spot_common_tags, {
+    mitre_attack_ids = "TA0040:T1496"
+  })
+}
+
+query "ec2_spot_instance_interrupted" {
+  sql = <<-EOQ
+    select
+      ${local.detection_sql_resource_column_request_parameters_instance_id}
+    from
+      aws_cloudtrail_log
+    where
+      event_source = 'ec2.amazonaws.com'
+      and (
+        event_name = 'CancelSpotInstanceRequests'
+        or (
+          event_name = 'TerminateInstances' 
+          and json_contains(request_parameters, 'spotInstanceRequestId')
+        )
+      )
+      ${local.detection_sql_where_conditions}
+    order by
+      event_time desc;
+  EOQ
+
+  tags = local.ec2_spot_common_tags
+}

--- a/detections/secretsmanager.pp
+++ b/detections/secretsmanager.pp
@@ -1,0 +1,58 @@
+locals {
+  secretsmanager_common_tags = merge(local.aws_cloudtrail_log_detections_common_tags, {
+    folder  = "Secrets Manager"
+    service = "AWS/SecretsManager"
+  })
+}
+
+benchmark "secretsmanager_detections" {
+  title       = "Secrets Manager Detections"
+  description = "This benchmark contains recommendations when scanning CloudTrail logs for AWS Secrets Manager events."
+  type        = "detection"
+  children = [
+    detection.secretsmanager_rotation_failures,
+  ]
+
+  tags = merge(local.secretsmanager_common_tags, {
+    type = "Benchmark"
+  })
+}
+
+detection "secretsmanager_rotation_failures" {
+  title           = "AWS Secrets Manager Secret Rotation Failures"
+  description     = "Detect when AWS Secrets Manager rotation fails for secrets. Failed rotations can lead to credential expiration, service disruptions, or continued use of potentially compromised credentials, increasing security risk."
+  documentation   = file("./detections/docs/secretsmanager_rotation_failures.md")
+  severity        = "medium"
+  display_columns = local.detection_display_columns
+  query           = query.secretsmanager_rotation_failures
+
+  tags = merge(local.secretsmanager_common_tags, {
+    mitre_attack_ids = "TA0006:T1552"
+    recommended      = "true"
+  })
+}
+
+query "secretsmanager_rotation_failures" {
+  sql = <<-EOQ
+    select
+      coalesce(json_extract_string(request_parameters, '$.secretId'), 'Unknown Secret') as resource,
+      event_time,
+      error_code,
+      error_message,
+      user_identity.arn as user_arn
+    from
+      aws_cloudtrail_log
+    where
+      event_source = 'secretsmanager.amazonaws.com'
+      and (
+        (event_name = 'RotateSecret' and error_code is not null)
+        or (event_name = 'GetSecretValue' and error_code = 'AccessDeniedException')
+        or (event_name = 'PutSecretValue' and error_code is not null)
+      )
+      ${local.detection_sql_where_conditions}
+    order by
+      event_time desc;
+  EOQ
+
+  tags = local.secretsmanager_common_tags
+}


### PR DESCRIPTION
This PR adds three new CloudTrail log detections:

1. **EC2 Spot Instance Interrupted** - Detects when EC2 spot instances are interrupted, which can disrupt workloads if not properly handled.

2. **CodeBuild Project Build Failures** - Detects when CodeBuild projects fail repeatedly, which may indicate configuration issues, security vulnerabilities, or potential supply chain attacks.

3. **AWS Secrets Manager Secret Rotation Failures** - Detects when AWS Secrets Manager fails to rotate secrets, which can lead to credential expiration or continued use of potentially compromised credentials.

Each detection includes:
- Full documentation with security impact analysis
- Query optimized for DuckDB
- Appropriate severity ratings
- MITRE ATT&CK framework mappings

These detections enhance security monitoring capabilities for critical AWS services.